### PR TITLE
PKGBUILD: Changed undeclared '_kernel_tag' variable to prevent name conflicts

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -159,7 +159,7 @@ _package-headers() {
 
   echo "Adding symlink..."
   mkdir -p "$pkgdir/usr/src"
-  ln -sr "$builddir" "$pkgdir/usr/src/linux-$_kernel_tag"
+  ln -sr "$builddir" "$pkgdir/usr/src/$pkgbase"
 }
 
 for _p in ${pkgname[@]}; do


### PR DESCRIPTION
I found this when I was trying to install some linux headers from your PKGBUILDs.
Also in:
[linux-rkbsp6.1-joshua-git](https://github.com/7Ji-PKGBUILDs/linux-rkbsp6.1-joshua-git/tree/master)
[linux-rockchip-joshua-git](https://github.com/7Ji-PKGBUILDs/linux-rockchip-joshua-git)
[linux-joshua-git](https://github.com/7Ji-PKGBUILDs/linux-joshua-git)